### PR TITLE
Add status bar setting

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-wakatime",
   "name": "WakaTime",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "minAppVersion": "0.15.0",
   "description": "Automatic time tracking and metrics generated from your Obsidian usage activity.",
   "author": "WakaTime",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-wakatime",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Automatic time tracking and metrics generated from your Obsidian usage activity.",
   "main": "main.js",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -134,7 +134,7 @@ export default class WakaTime extends Plugin {
     return this.lastHeartbeat + 120000 < time;
   }
 
-  private updateStatusBarText(text?: string): void {
+  public updateStatusBarText(text?: string): void {
     if (!this.statusBar) return;
     if (!text) {
       this.statusBar.setText('');

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -22,6 +22,8 @@ export class SettingsTab extends PluginSettingTab {
           .setValue(this.plugin.settings.showStatusBar)
           .onChange(async (value) => {
             this.plugin.settings.showStatusBar = value;
+            this.plugin.updateStatusBarText();
+            this.plugin.showStatusBar = value;
             await this.plugin.saveSettings();
           })
       );

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -1,0 +1,29 @@
+import { App, PluginSettingTab, Setting } from "obsidian";
+import WakaTime from "./main";
+
+export class SettingsTab extends PluginSettingTab {
+  plugin: WakaTime;
+
+  constructor(app: App, plugin: WakaTime) {
+    super(app, plugin);
+    this.plugin = plugin;
+  }
+
+  display(): void {
+    let { containerEl } = this;
+
+    containerEl.empty();
+
+    new Setting(containerEl)
+      .setName("Show time in status bar")
+      .setDesc("Show time browsing, meeting, coding and debugging in status bar.")
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.showStatusBar)
+          .onChange(async (value) => {
+            this.plugin.settings.showStatusBar = value;
+            await this.plugin.saveSettings();
+          })
+      );
+  }
+}


### PR DESCRIPTION
Adds a settings page for the plugin, which allows us to toggle status bar information.

<img width="775" alt="image" src="https://github.com/wakatime/obsidian-wakatime/assets/17620692/17aa557e-6283-4991-90da-89d67920435f">

Status bar with setting **disabled**:
<img width="292" alt="image" src="https://github.com/wakatime/obsidian-wakatime/assets/17620692/f7e17b4f-76e6-4fb4-863b-92eb35a9993b">

Status bar with setting **enabled** (current behaviour):
<img width="809" alt="image" src="https://github.com/wakatime/obsidian-wakatime/assets/17620692/47aa847a-384e-4033-8dcb-ee3297866ff1">
